### PR TITLE
Bump gradle to 7.3 (for building with java 17) and remove parchment from build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,18 +45,12 @@ repositories {
 		name = "Sonatype Snapshots"
 		url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
 	}
-
-    maven {
-        name = "ldtteam"
-        url = uri("https://ldtteam.jfrog.io/artifactory/parchmentmc-snapshots/")
-    }
 }
 
 dependencies {
 	minecraft("net.minecraft", "minecraft", properties["minecraft_version"].toString())
 	mappings(loom.layered {
 		officialMojangMappings()
-		parchment("org.parchmentmc.data:parchment-1.17.1:2021.10.25-nightly-SNAPSHOT@zip")
 	})
 	modImplementation("net.fabricmc", "fabric-loader", properties["loader_version"].toString())
 	modImplementation("net.fabricmc", "fabric-language-kotlin", "1.6.4+kotlin.1.5.30")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7.3 adds support for building with java 17, the latest LTS version of java.

I also removed parchment from gradle.build.kts as it seems it's not needed at all... and it makes the build fail.