### PR TITLE
Update github actions to use JDK 18.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         java:
-          - 17
+          - 18
         os:
           - ubuntu-20.04
           - windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         java:
-          - 16
+          - 17
         os:
           - ubuntu-20.04
           - windows-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: 17
       - name: Publish
         run: ./gradlew publishAllPublicationsToHydosRepository
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 17
+      - name: Set up JDK 18
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 18
       - name: Publish
         run: ./gradlew publishAllPublicationsToHydosRepository
         env:


### PR DESCRIPTION
The title says it all, Basically makes gradlew run properly instead of outright crashing for saying that JDK 17 is wanted.

*(not sure what to do with the build.gradle.kts file though)*